### PR TITLE
Disable boost::recursive_wrapper maybe-uninitialized flags on GCC 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(${LIB_TARGET_NAME}
 if(NOT MSVC)
     target_compile_options(boost_assert INTERFACE -Wno-error-parentheses -Wno-parentheses)
     target_compile_options(boost_filesystem PRIVATE -Wno-error-deprecated-declarations -Wno-deprecated-declarations)
-    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror)
+    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror -Wno-error-maybe-uninitialized)
 endif()
 
 if (JINJA2CPP_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,9 @@ target_include_directories(${LIB_TARGET_NAME}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(NOT MSVC)
-    target_compile_options(boost_assert INTERFACE -Wno-error-parentheses -Wno-parentheses)
-    target_compile_options(boost_filesystem PRIVATE -Wno-error-deprecated-declarations -Wno-deprecated-declarations)
-    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror -Wno-error-maybe-uninitialized)
+    target_compile_options(boost_assert INTERFACE -Wno-error=parentheses -Wno-parentheses)
+    target_compile_options(boost_filesystem PRIVATE -Wno-error=deprecated-declarations -Wno-deprecated-declarations)
+    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror -Wno-error=maybe-uninitialized)
 endif()
 
 if (JINJA2CPP_BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0.2)
 project(Jinja2Cpp VERSION 0.5.0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -55,10 +55,25 @@ target_link_libraries(${LIB_TARGET_NAME} PUBLIC ThirdParty::nonstd boost_variant
 target_include_directories(${LIB_TARGET_NAME}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+
 if(NOT MSVC)
-    target_compile_options(boost_assert INTERFACE -Wno-error=parentheses -Wno-parentheses)
-    target_compile_options(boost_filesystem PRIVATE -Wno-error=deprecated-declarations -Wno-deprecated-declarations)
-    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror -Wno-error=maybe-uninitialized)
+    # Enable -Werror and -Wall on jinja2cpp target, ignoring warning errors from thirdparty libs
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag(-Wno-error=parentheses COMPILER_HAS_WNO_ERROR_PARENTHESES_FLAG)
+    check_cxx_compiler_flag(-Wno-error=deprecated-declarations COMPILER_HAS_WNO_ERROR_DEPRECATED_DECLARATIONS_FLAG)
+    check_cxx_compiler_flag(-Wno-error=maybe-uninitialized COMPILER_HAS_WNO_ERROR_MAYBE_UNINITIALIZED_FLAG)
+
+    if(COMPILER_HAS_WNO_ERROR_PARENTHESES_FLAG)
+        target_compile_options(boost_assert INTERFACE -Wno-error=parentheses)
+    endif()
+    if(COMPILER_HAS_WNO_ERROR_DEPRECATED_DECLARATIONS_FLAG)
+        target_compile_options(boost_filesystem PRIVATE -Wno-error=deprecated-declarations)
+    endif()
+    if(COMPILER_HAS_WNO_ERROR_MAYBE_UNINITIALIZED_FLAG)
+        target_compile_options(boost_variant INTERFACE -Wno-error=maybe-uninitialized)
+    endif()
+
+    target_compile_options(${LIB_TARGET_NAME} PRIVATE -Wall -Werror)
 endif()
 
 if (JINJA2CPP_BUILD_TESTS)


### PR DESCRIPTION
It worked locally with that same compiler. I'm using [this CI pipeline](https://gitlab.com/Manu343726/tinyrefl/pipelines/31812230) as reference.