### PR TITLE
Tag ListAdapter::Iterator as a forward iterator

### DIFF
--- a/src/internal_value.h
+++ b/src/internal_value.h
@@ -358,7 +358,7 @@ class ListAdapter::Iterator
         : public boost::iterator_facade<
             Iterator,
             const InternalValue,
-            boost::single_pass_traversal_tag>
+            boost::forward_traversal_tag>
 {
 public:
     Iterator()


### PR DESCRIPTION
This fixes the build with libcxx which currently fails with:

```
In file included from jinja2cpp/src/filters.cpp:1:
In file included from jinja2cpp/src/filters.h:4:
In file included from jinja2cpp/src/expression_evaluator.h:4:
In file included from jinja2cpp/src/internal_value.h:4:
In file included from jinja2cpp/include/jinja2cpp/value.h:6:
In file included from libcxx/include/vector:274:
In file included from libcxx/include/__bit_reference:15:
libcxx/include/algorithm:2493:5: error: static_assert failed due to requirement '__is_forward_iterator<Iterator>::value' "std::max_element requires a ForwardIterator"
    static_assert(__is_forward_iterator<_ForwardIterator>::value,
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```