### PR TITLE
Fix filters_tests that depend on sorting order

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -659,7 +659,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
         for (auto& v : list)
             items.push_back(Item{IsEmpty(attrName) ? v : Subscript(v, attrName), idx ++});
 
-        std::sort(items.begin(), items.end(), [&compType](auto& i1, auto& i2) {
+        std::stable_sort(items.begin(), items.end(), [&compType](auto& i1, auto& i2) {
             auto cmpRes = Apply2<visitors::BinaryMathOperation>(i1.val, i2.val, BinaryExpression::LogicalLt, compType);
 
             return ConvertToBool(cmpRes);
@@ -672,7 +672,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
         });
         items.erase(end, items.end());
 
-        std::sort(items.begin(), items.end(), [](auto& i1, auto& i2) {
+        std::stable_sort(items.begin(), items.end(), [](auto& i1, auto& i2) {
             return i1.idx < i2.idx;
         });
 

--- a/test/filters_test.cpp
+++ b/test/filters_test.cpp
@@ -426,7 +426,7 @@ INSTANTIATE_TEST_CASE_P(Convert, FilterGenericTest, ::testing::Values(
                             InputOutputPair{"'100' | int(10, base=8) | pprint", "64"},
                             InputOutputPair{"'100' | int(10, base=16) | pprint", "256"},
                             InputOutputPair{"'100' | list | pprint", "['1', '0', '0']"},
-                            InputOutputPair{"{'name'='itemName', 'val'='itemValue'} | list | pprint", "['name', 'val']"}
+                            InputOutputPair{"{'name'='itemName', 'val'='itemValue'} | list | sort | pprint", "['name', 'val']"}
                             ));
 
 INSTANTIATE_TEST_CASE_P(Trim, FilterGenericTest, ::testing::Values(


### PR DESCRIPTION
The switch to stable_sort makes the `unique` operator deterministically return
the first unique elements.

Fixes Convert/FilterGenericTest/14:

     jinja2cpp/test/test_tools.h:128
           Expected: expectedResult
           Which is: "['name', 'val']"
     To be equal to: result
           Which is: "['val', 'name']"

and Unique/ListIteratorTest/9:

     jinja2cpp/test/filters_test.cpp:28
           Expected: expectedResult
           Which is: "test string 0, test string 1"
     To be equal to: result
           Which is: "test string 0, test string 5"