### PR TITLE
fix: c++20 compilation

### DIFF
--- a/src/error_info.cpp
+++ b/src/error_info.cpp
@@ -126,53 +126,53 @@ void RenderErrorInfo(std::basic_string<CharT>& result, const ErrorInfoTpl<CharT>
     switch (errCode)
     {
     case ErrorCode::Unspecified:
-            format_to(std::back_inserter(out), UNIVERSAL_STR("Parse error").GetValue<CharT>());
+            fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Parse error").GetValue<CharT>());
             break;
     case ErrorCode::UnexpectedException:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected exception occurred during template processing. Exception: {}").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected exception occurred during template processing. Exception: {}").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::MetadataParseError:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Error occurred during template metadata parsing. Error: {}").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Error occurred during template metadata parsing. Error: {}").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::YetUnsupported:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("This feature has not been supported yet").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("This feature has not been supported yet").GetValue<CharT>());
         break;
     case ErrorCode::FileNotFound:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("File not found").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("File not found").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedStringLiteral:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("String expected").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("String expected").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedIdentifier:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Identifier expected").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Identifier expected").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedSquareBracket:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("']' expected").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("']' expected").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedRoundBracket:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("')' expected").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("')' expected").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedCurlyBracket:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("'}}' expected").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("'}}' expected").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedToken:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected token '{}'").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected token '{}'").GetValue<CharT>(), extraParams[0]);
         if (extraParams.size() > 1)
         {
-            format_to(std::back_inserter(out), UNIVERSAL_STR(". Expected: ").GetValue<CharT>());
+            fmt::format_to(std::back_inserter(out), UNIVERSAL_STR(". Expected: ").GetValue<CharT>());
             for (std::size_t i = 1; i < extraParams.size(); ++ i)
             {
                 if (i != 1)
-                    format_to(std::back_inserter(out), UNIVERSAL_STR(", ").GetValue<CharT>());
-                format_to(std::back_inserter(out), UNIVERSAL_STR("\'{}\'").GetValue<CharT>(), extraParams[i]);
+                    fmt::format_to(std::back_inserter(out), UNIVERSAL_STR(", ").GetValue<CharT>());
+                fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("\'{}\'").GetValue<CharT>(), extraParams[i]);
             }
         }
         break;
@@ -180,83 +180,83 @@ void RenderErrorInfo(std::basic_string<CharT>& result, const ErrorInfoTpl<CharT>
     case ErrorCode::ExpectedExpression:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Expected expression, got: '{}'").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Expected expression, got: '{}'").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::ExpectedEndOfStatement:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of statement, got: '{}'").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of statement, got: '{}'").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::ExpectedRawEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of raw block").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of raw block").GetValue<CharT>());
         break;
     case ErrorCode::ExpectedMetaEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of meta block").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Expected end of meta block").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedToken:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected token: '{}'").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected token: '{}'").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::UnexpectedStatement:
     {
         auto& extraParams = errInfo.GetExtraParams();
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement: '{}'").GetValue<CharT>(), extraParams[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement: '{}'").GetValue<CharT>(), extraParams[0]);
         break;
     }
     case ErrorCode::UnexpectedCommentBegin:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected comment begin").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected comment begin").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedCommentEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected comment end").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected comment end").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedRawBegin:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected raw block begin").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected raw block begin").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedRawEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected raw block end").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected raw block end").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedMetaBegin:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected meta block begin").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected meta block begin").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedMetaEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected meta block end").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected meta block end").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedExprBegin:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected expression block begin").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected expression block begin").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedExprEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected expression block end").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected expression block end").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedStmtBegin:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement block begin").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement block begin").GetValue<CharT>());
         break;
     case ErrorCode::UnexpectedStmtEnd:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement block end").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Unexpected statement block end").GetValue<CharT>());
         break;
     case ErrorCode::TemplateNotParsed:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Template not parsed").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Template not parsed").GetValue<CharT>());
         break;
     case ErrorCode::TemplateNotFound:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Template(s) not found: {}").GetValue<CharT>(), errInfo.GetExtraParams()[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Template(s) not found: {}").GetValue<CharT>(), errInfo.GetExtraParams()[0]);
         break;
     case ErrorCode::InvalidTemplateName:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Invalid template name: {}").GetValue<CharT>(), errInfo.GetExtraParams()[0]);
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Invalid template name: {}").GetValue<CharT>(), errInfo.GetExtraParams()[0]);
         break;
     case ErrorCode::InvalidValueType:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Invalid value type").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Invalid value type").GetValue<CharT>());
         break;
     case ErrorCode::ExtensionDisabled:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Extension disabled").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Extension disabled").GetValue<CharT>());
         break;
     case ErrorCode::TemplateEnvAbsent:
-        format_to(std::back_inserter(out), UNIVERSAL_STR("Template environment doesn't set").GetValue<CharT>());
+        fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("Template environment doesn't set").GetValue<CharT>());
         break;
     }
-    format_to(std::back_inserter(out), UNIVERSAL_STR("\n{}").GetValue<CharT>(), errInfo.GetLocationDescr());
+    fmt::format_to(std::back_inserter(out), UNIVERSAL_STR("\n{}").GetValue<CharT>(), errInfo.GetLocationDescr());
     result = to_string(out);
 }
 

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -415,7 +415,7 @@ InternalValue Map::Filter(const InternalValue& baseVal, RenderContext& context)
 
     return ListAdapter::CreateAdapter(std::move(resultList));
 }
-Random::Random(FilterParams params) {}
+Random::Random(FilterParams) {}
 
 InternalValue Random::Filter(const InternalValue&, RenderContext&)
 {
@@ -458,7 +458,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
 
     if (!isConverted)
         return result;
-    
+
     auto ProtectedValue = [&baseVal](InternalValue value) {
         if (baseVal.ShouldExtendLifetime())
             value.SetParentData(baseVal);
@@ -667,7 +667,7 @@ InternalValue Slice::Filter(const InternalValue& baseVal, RenderContext& context
             value.SetParentData(baseVal);
         return value;
     };
-    
+
     InternalValue sliceLengthValue = GetArgumentValue("slices", context);
     int64_t sliceLength = ConvertToInt(sliceLengthValue);
     InternalValue fillWith = GetArgumentValue("fill_with", context);
@@ -719,13 +719,13 @@ InternalValue Slice::Batch(const InternalValue& baseVal, RenderContext& context)
 
     InternalValueList resultList;
     resultList.reserve(linecount);
-    
+
     auto ProtectedValue = [&baseVal](InternalValue value) {
         if (baseVal.ShouldExtendLifetime())
             value.SetParentData(baseVal);
         return value;
     };
-    
+
     const auto remainder = elementsCount % linecount;
     const auto columns = elementsCount / linecount + (remainder > 0 ? 1 : 0);
     for (std::size_t line = 0, idx = 0; line < linecount; ++line)

--- a/src/serialize_filters.cpp
+++ b/src/serialize_filters.cpp
@@ -124,7 +124,7 @@ struct PrettyPrinter : visitors::BaseVisitor<std::string>
     const RenderContext* m_context;
 };
 
-PrettyPrint::PrettyPrint(FilterParams params) {}
+PrettyPrint::PrettyPrint(FilterParams) {}
 
 InternalValue PrettyPrint::Filter(const InternalValue& baseVal, RenderContext& context)
 {


### PR DESCRIPTION
There was an ambiguity for the `format_to` function since there is [one in the srandart](https://en.cppreference.com/w/cpp/utility/format/format_to).