### PR TITLE
fix(cmake/install): Remove 3rd parties installed files that don't exist anymore

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -90,3 +90,7 @@ jobs:
       run: |
         cd .build && ctest -C $BUILD_CONFIG -V
 
+    - name: Install
+      run: |
+        DESTDIR=$RUNNER_TEMP cmake --install .build --verbose
+

--- a/thirdparty/internal_deps.cmake
+++ b/thirdparty/internal_deps.cmake
@@ -75,13 +75,6 @@ if (JINJA2CPP_BUILD_TESTS)
     FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-install (FILES
-        thirdparty/nonstd/expected-lite/include/nonstd/expected.hpp
-        thirdparty/nonstd/variant-lite/include/nonstd/variant.hpp
-        thirdparty/nonstd/optional-lite/include/nonstd/optional.hpp
-        thirdparty/nonstd/string-view-lite/include/nonstd/string_view.hpp
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/nonstd)
-
 install (TARGETS RapidJson
     EXPORT InstallTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
3rd parties files are installed through their own fetched packages
instead of git submodules (which was the previous mechanism, as per
https://github.com/jinja2cpp/Jinja2Cpp/commit/11ebd1e3dec209c9d972e077c967f6ac58e3350b).