### PR TITLE
Change +, -, *, /, //, and % operators' associativity to left-to-right

### DIFF
--- a/src/expression_parser.cpp
+++ b/src/expression_parser.cpp
@@ -196,64 +196,67 @@ ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionPars
 
 ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionParser::ParseMathPlusMinus(LexScanner& lexer)
 {
-    auto left = ParseMathMulDiv(lexer);
-    if (!left)
-        return left;
-
-    auto tok = lexer.NextToken();
-    BinaryExpression::Operation operation;
-    switch (tok.type)
-    {
-    case '+':
-        operation = BinaryExpression::Plus;
-        break;
-    case '-':
-        operation = BinaryExpression::Minus;
-        break;
-    default:
-        lexer.ReturnToken();
-        return left;
+    auto res = ParseMathMulDiv(lexer);
+    if (!res)
+        return res;
+    
+    while (true) {
+        auto tok = lexer.NextToken();
+        BinaryExpression::Operation operation;
+        switch (tok.type)
+        {
+        case '+':
+            operation = BinaryExpression::Plus;
+            break;
+        case '-':
+            operation = BinaryExpression::Minus;
+            break;
+        default:
+            lexer.ReturnToken();
+            return res;
+        }
+        auto right = ParseMathMulDiv(lexer);
+        if (!right)
+            return res;
+        res = std::make_shared<BinaryExpression>(operation, *res, *right);
     }
-
-    auto right = ParseMathPlusMinus(lexer);
-    if (!right)
-        return right;
-
-    return std::make_shared<BinaryExpression>(operation, *left, *right);
+    return res;
 }
 
 ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionParser::ParseMathMulDiv(LexScanner& lexer)
 {
-    auto left = ParseUnaryPlusMinus(lexer);
-    if (!left)
-        return left;
-
-    auto tok = lexer.NextToken();
-    BinaryExpression::Operation operation;
-    switch (tok.type)
-    {
-    case '*':
-        operation = BinaryExpression::Mul;
-        break;
-    case '/':
-        operation = BinaryExpression::Div;
-        break;
-    case Token::DivDiv:
-        operation = BinaryExpression::DivInteger;
-        break;
-    case '%':
-        operation = BinaryExpression::DivRemainder;
-        break;
-    default:
-        lexer.ReturnToken();
-        return left;
+    auto res = ParseUnaryPlusMinus(lexer);
+    if (!res)
+        return res;
+    
+    while (true) {
+        auto tok = lexer.NextToken();
+        BinaryExpression::Operation operation;
+        switch (tok.type)
+        {
+        case '*':
+            operation = BinaryExpression::Mul;
+            break;
+        case '/':
+            operation = BinaryExpression::Div;
+            break;
+        case Token::DivDiv:
+            operation = BinaryExpression::DivInteger;
+            break;
+        case '%':
+            operation = BinaryExpression::DivRemainder;
+            break;
+        default:
+            lexer.ReturnToken();
+            return res;
+        }
+        auto right = ParseUnaryPlusMinus(lexer);
+        if (!right)
+            return res;
+        res = std::make_shared<BinaryExpression>(operation, *res, *right);
     }
-
-    auto right = ParseMathMulDiv(lexer);
-    if (!right)
-        return right;
-
-    return std::make_shared<BinaryExpression>(operation, *left, *right);
+    
+    return res;
 }
 
 ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionParser::ParseUnaryPlusMinus(LexScanner& lexer)

--- a/src/expression_parser.cpp
+++ b/src/expression_parser.cpp
@@ -217,7 +217,7 @@ ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionPars
         }
         auto right = ParseMathMulDiv(lexer);
         if (!right)
-            return res;
+            return right;
         res = std::make_shared<BinaryExpression>(operation, *res, *right);
     }
     return res;
@@ -252,7 +252,7 @@ ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionPars
         }
         auto right = ParseUnaryPlusMinus(lexer);
         if (!right)
-            return res;
+            return right;
         res = std::make_shared<BinaryExpression>(operation, *res, *right);
     }
     

--- a/test/expressions_test.cpp
+++ b/test/expressions_test.cpp
@@ -24,6 +24,8 @@ R"(
 {{ 3 ** 4 }}
 {{ 10 ** -2 }}
 {{ 10/10 + 2*5 }}
+{{ 10 - 2 - 4 }}
+{{ 200 / 2 / 2 }}
 {{ ([1, 2] + [3, 4]) | pprint }}
 {{ 'Hello' + " " + 'World ' + stringValue }}
 {{ 'Hello' + " " + 'World ' + wstringValue }}
@@ -53,6 +55,8 @@ R"(
 81
 0.01
 11
+4
+50
 [1, 2, 3, 4]
 Hello World rain
 Hello World rain


### PR DESCRIPTION
Before:

* Expressions like 10 - 2 - 4 parsed as 10 - (2 - 4) instead of more convenient (10 - 2) - 4
* Expressions like 200 / 2 / 2 parsed as 100 / (2 / 2) instead of more convenient (200 / 2) / 2

Now:

* Fixed it
* Added corresponding test