### PR TITLE
fix interpreting optional with 0 value as true in checks

### DIFF
--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -487,7 +487,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
     switch (m_mode)
     {
         case FirstItemMode:
-            if (listSize)
+            if (listSize && *listSize > 0)
                 result = ProtectedValue( list.GetValueByIndex(0) );
             else
             {
@@ -497,7 +497,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
             }
             break;
         case LastItemMode:
-            if (listSize)
+            if (listSize && *listSize > 0)
                 result = ProtectedValue(list.GetValueByIndex(listSize.value() - 1));
             else
             {
@@ -508,7 +508,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
             }
             break;
         case LengthMode:
-            if (listSize)
+            if (listSize && *listSize > 0)
                 result = static_cast<int64_t>(listSize.value());
             else
                 result = static_cast<int64_t>(std::distance(list.begin(), list.end()));
@@ -517,7 +517,7 @@ InternalValue SequenceAccessor::Filter(const InternalValue& baseVal, RenderConte
         {
             std::random_device rd;
             std::mt19937 gen(rd());
-            if (listSize)
+            if (listSize && *listSize > 0)
             {
                 std::uniform_int_distribution<> dis(0, static_cast<int>(listSize.value()) - 1);
                 result = ProtectedValue(list.GetValueByIndex(dis(gen)));


### PR DESCRIPTION
here listSize из optional<size_t> 
so acessing lists with zero elems produces segfault (or other ub behavior)